### PR TITLE
Update this repo to use the new NameGame API endpoint

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,19 +96,20 @@
          * The data comes back in the format:
          *
          *    [
-         *        { name: 'Viju Legard', url: '...' },
-         *        { name: 'Matt Seibert', url: '...' },
+         *        { firstName: 'Viju,  lastName: 'Legard',  headshot: { url: '...' } },
+         *        { firstName: 'Matt', lastName: 'Seibert', headshot: { url: '...' } },
          *        ...
          *    ]
          */
         function getPersonList() {
             return new Promise((resolve, reject) => {
-                fetch('http://api.namegame.willowtreemobile.com/').then(function(response) {
+                fetch('https://willowtreeapps.com/api/v1.0/profiles')
+                .then(response => {
                     if (response.status !== 200) {
                         reject(new Error("Error!"));
                     }
 
-                    response.json().then((imageList) => {
+                    response.json().then(imageList => {
                         resolve(imageList);
                     });
                 });
@@ -123,12 +124,18 @@
          ***************************************************/
 
 
-        function getLastName(fullName) {
-            return fullName.match(/\w+/g)[1];
+        function getLastName(person) {
+            return person.lastName;
         }
 
-        const getFirstName = (fullName) => {
-            return fullName.match(/\w+/g)[0];
+        const getFirstName = (person) => {
+            return person.firstName;
+        };
+
+        // headshot URLs are scheme relative //
+        // prepend http: to prevent invalid schemes like file:// or uri://
+        const getImageUrl = (person) => {
+            return `http:${person.headshot.url}`;
         };
 
         /**
@@ -157,7 +164,7 @@
          */
         function filterByName(searchForName, personList) {
             return personList.filter((person) => {
-                return person.name === searchForName;
+                return person.firstName === searchForName || person.lastName === searchForName;
             });
         }
 
@@ -199,7 +206,7 @@
             };
         }
 
-        const sortByFirstName = sortObjListByProp('name');
+        const sortByFirstName = sortObjListByProp('firstName');
 
         const sortByLastName = (personList) => sortByFirstName(personList).reverse();
 
@@ -220,10 +227,10 @@
             src: props.src
         });
 
-        const ListRow = (props) => React.DOM.tr({ key: props.person.name }, [
-            React.DOM.td({ key: 'thumb' }, React.createElement(Thumbnail, { src: props.person.url })),
-            React.DOM.td({ key: 'first' }, null, getFirstName(props.person.name)),
-            React.DOM.td({ key: 'last' }, null, getLastName(props.person.name)),
+        const ListRow = (props) => React.DOM.tr({ key: `${props.person.firstName} ${props.person.lastName}` }, [
+            React.DOM.td({ key: 'thumb' }, React.createElement(Thumbnail, { src: getImageUrl(props.person) })),
+            React.DOM.td({ key: 'first' }, null, getFirstName(props.person)),
+            React.DOM.td({ key: 'last' }, null, getLastName(props.person)),
         ]);
 
         const ListContainer = (props) => React.DOM.table({ className: 'list-container' }, [


### PR DESCRIPTION
Summary of changes:

1. Now using `https://willowtreeapps.com/api/v1.0/profiles` as the new endpoint
2. Updating helper functions to use new JSON response format
3. Submit PR to willowtreeapps.com repo to pull all people for the namegame API endpoint, not just the first 100 that Contentful returns by default: willowtreeapps/willowtreeapps.com#439

TODO:
1. Some people don't have images in contentful, should this be left as is or filtered out
2. The api endpoint only returns the first 100 'people' objects from Contentful due to the way requests are paged, additional work will be needed to get all people in a single response
3. Matt fixed a CORS bug in the willowtreeapps.com routing logic to add the correct CORS headers for cached and non-cached requests to the namegame endpoint. This won't be available until the next website release, so for the time being only the first request will succeed (willowtreeapps/willowtreeapps.com#438)